### PR TITLE
Add simple footer

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1,5 +1,10 @@
 <!DOCTYPE html>
 <html>
+  <style>
+  body {
+    margin: 0
+  }
+  </style>
   <head>
     <title>Jupyter!</title>
   </head>

--- a/src/components/NavFooter/NavFooter.css
+++ b/src/components/NavFooter/NavFooter.css
@@ -1,0 +1,24 @@
+.navfooter {
+  width: "100%";
+  height: "300px";
+  background: "#0B5E9B";
+  color: "white";
+}
+
+.navfooter .iconrow {
+    text-align: "center";
+    top: "50%";
+    position: "relative";
+}
+
+.navfooter .iconrow img {
+    height: 36px;
+    width: 36px;
+}
+
+.navfooter .textrow {
+    top: "20%";
+    position: "relative";
+}
+
+

--- a/src/components/NavFooter/NavFooter.tsx
+++ b/src/components/NavFooter/NavFooter.tsx
@@ -1,0 +1,58 @@
+import React, { HTMLAttributes, CSSProperties } from "react"
+import Body2Text from "../Body2Text";
+
+function NavFooter(props: HTMLAttributes<HTMLDivElement>) {
+  const footerStyle: CSSProperties = {
+    width: "100%",
+    height: "300px",
+    background: "#0B5E9B",
+    color: "white",
+  }
+
+ const footerTextStyle: CSSProperties = {
+  textAlign: "center",
+  paddingTop: "63px",
+}
+
+const footerIconStyle: CSSProperties = {
+  maxHeight: "30px",
+  display: "inline-block",
+}
+
+const footerCenterIconStyle: CSSProperties = {
+  ...footerIconStyle,
+  paddingLeft: "85px",
+  paddingRight: "85px",
+}
+
+const footerIconRowStyle: CSSProperties = {
+  paddingTop: "60px",
+  maxHeight: "30px",
+  textAlign: "center",
+}
+
+  return (
+    <div style={footerStyle} {...props}>
+      <div style={footerIconRowStyle}>
+      <a href="http://homepages.cae.wisc.edu/~ece533/images/airplane.png">
+        <img style={footerIconStyle} src="http://homepages.cae.wisc.edu/~ece533/images/airplane.png"></img>
+      </a>
+      <a href="http://homepages.cae.wisc.edu/~ece533/images/airplane.png">
+        <img style={footerCenterIconStyle} src="http://homepages.cae.wisc.edu/~ece533/images/airplane.png"></img>
+      </a>
+      <a href="http://homepages.cae.wisc.edu/~ece533/images/airplane.png">
+        <img style={footerIconStyle} src="http://homepages.cae.wisc.edu/~ece533/images/airplane.png"></img>
+      </a>
+      </div>
+      <div style={footerTextStyle}>
+        <Body2Text>Copyright ©️ 2019 Project Jupyter</Body2Text>
+        <Body2Text>Last updated Fri, Oct 4, 2019</Body2Text>
+        <br/>
+        <Body2Text>The Jupyter Trademark is registered with the U.S. Patent &</Body2Text>
+        <Body2Text>Trademark office.</Body2Text>
+      </div>
+    </div>
+  );
+}
+
+export default NavFooter;

--- a/src/components/NavFooter/index.ts
+++ b/src/components/NavFooter/index.ts
@@ -1,0 +1,3 @@
+import NavFooter from './NavFooter';
+
+export default NavFooter;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,10 +19,12 @@ import Body2Text from "./components/Body2Text";
 import CaptionText from "./components/CaptionText";
 import OverlineText from "./components/OverlineText";
 import {Button, ButtonMode, ButtonText} from "./components/Button";
+import NavFooter from "./components/NavFooter";
 
 // code
 ReactDOM.render(
     <div>
+    <NavFooter/>
     <Button onClick={console.log} mode={ButtonMode.Contained}>
         Button Label
     </Button>


### PR DESCRIPTION
closes #16 
![image](https://user-images.githubusercontent.com/2541209/66416488-c3cdb680-e9b2-11e9-9e09-ff9cdccd3f48.png)

There are a few open questions:
1. should the footer stretch horizontally? Right now, I have it so it always takes up 100% of the width of the page.
2. I wish the styling was a bit easier to read, cc @jameswenzel and #29 
3. I would like to put icons where the default images are, but we don't have them yet.
4. It might be useful to make an Icon component, see #30 
5. The icons in the design document were all different sizes, so I set the height of the row to exactly 30px and the separation to exactly 85px.